### PR TITLE
Added rx_time_valid variable

### DIFF
--- a/src/aprs.c
+++ b/src/aprs.c
@@ -947,7 +947,7 @@ static bool aprs_parse_text_frame(const uint8_t *frame, size_t len, aprs_frame_t
 	}
 
 	textframe += ret + 1; // “remove” the processed text from the buffer
-	
+
 	// find end of path character
 	const char *end_of_path = strchr(textframe, ':');
 	if(!end_of_path) {
@@ -983,7 +983,7 @@ static bool aprs_parse_text_frame(const uint8_t *frame, size_t len, aprs_frame_t
 	}
 
 	textframe += ret + 1; // “remove” the processed text from the buffer
-	
+
 	char type = *textframe;
 	textframe++;
 
@@ -1108,6 +1108,7 @@ uint8_t aprs_rx_history_insert(
 		const aprs_frame_t *frame,
 		const aprs_rx_raw_data_t *raw,
 		uint64_t rx_timestamp,
+		bool rx_time_valid,
 		uint8_t protected_index)
 {
 	aprs_rx_history_entry_t *insert_pos = NULL;
@@ -1176,6 +1177,7 @@ uint8_t aprs_rx_history_insert(
 	// update the stored data
 	insert_pos->decoded = *frame;
 	insert_pos->rx_timestamp = rx_timestamp;
+	insert_pos->rx_time_valid = rx_time_valid;
 	insert_pos->raw = *raw;
 
 	// restore the data unavailable in the positionless frame
@@ -1194,4 +1196,16 @@ uint8_t aprs_rx_history_insert(
 const aprs_rx_history_t* aprs_get_rx_history(void)
 {
 	return &m_rx_history;
+}
+
+void aprs_rx_history_fix_timestamp(uint64_t unix_time)
+{
+	for(uint8_t i = 0; i < m_rx_history.num_entries; i++) {
+
+		if (!m_rx_history.history[i].rx_time_valid)
+		{
+			m_rx_history.history[i].rx_time_valid = true;
+			m_rx_history.history[i].rx_timestamp = unix_time - m_rx_history.history[i].rx_timestamp;
+		}
+	}
 }

--- a/src/aprs.c
+++ b/src/aprs.c
@@ -1198,6 +1198,14 @@ const aprs_rx_history_t* aprs_get_rx_history(void)
 	return &m_rx_history;
 }
 
+/**
+ * @brief Updates rx packet history entries timestamp
+ * @details The following funtion updates all history rx'ed packet
+ * containing an invalid rx timestamp, identified by rx_time_valid variable.
+ *
+ * @param unix_time The current Unix epoch timestamp to update the
+*					history entries.
+*/
 void aprs_rx_history_fix_timestamp(uint64_t unix_time)
 {
 	for(uint8_t i = 0; i < m_rx_history.num_entries; i++) {

--- a/src/aprs.h
+++ b/src/aprs.h
@@ -113,6 +113,7 @@ typedef struct {
 	aprs_rx_raw_data_t raw;
 	aprs_frame_t       decoded;
 	uint64_t           rx_timestamp;
+	bool               rx_time_valid;
 } aprs_rx_history_entry_t;
 
 typedef struct {
@@ -160,8 +161,11 @@ uint8_t aprs_rx_history_insert(
 		const aprs_frame_t *frame,
 		const aprs_rx_raw_data_t *raw,
 		uint64_t rx_timestamp,
+        bool rx_time_valid,
 		uint8_t protected_index);
 
 const aprs_rx_history_t* aprs_get_rx_history(void);
+
+void aprs_rx_history_fix_timestamp(uint64_t unix_time);
 
 #endif // APRS_H

--- a/src/aprs.h
+++ b/src/aprs.h
@@ -161,7 +161,7 @@ uint8_t aprs_rx_history_insert(
 		const aprs_frame_t *frame,
 		const aprs_rx_raw_data_t *raw,
 		uint64_t rx_timestamp,
-        bool rx_time_valid,
+		bool rx_time_valid,
 		uint8_t protected_index);
 
 const aprs_rx_history_t* aprs_get_rx_history(void);

--- a/src/main.c
+++ b/src/main.c
@@ -762,6 +762,7 @@ static void cb_lora(lora_evt_t evt, const lora_evt_data_t *data)
 
 	bool     decode_ok;
 	uint64_t rx_timestamp;
+	bool     rx_time_valid;
 
 	aprs_frame_t decoded_frame;
 	aprs_rx_raw_data_t raw;
@@ -773,6 +774,8 @@ static void cb_lora(lora_evt_t evt, const lora_evt_data_t *data)
 		case LORA_EVT_PACKET_RECEIVED:
 			// try to parse the packet.
 			rx_timestamp = wall_clock_get_unix();
+			rx_time_valid = wall_clock_is_valid();
+
 			decode_ok = aprs_parse_frame(
 			                       data->rx_packet_data.data,
 			                       data->rx_packet_data.data_len,
@@ -790,6 +793,7 @@ static void cb_lora(lora_evt_t evt, const lora_evt_data_t *data)
 						&decoded_frame,
 						&raw,
 						rx_timestamp,
+						rx_time_valid,
 						m_display_rx_index);
 
 				if(switch_to_rxd) {

--- a/src/wall_clock.c
+++ b/src/wall_clock.c
@@ -26,14 +26,18 @@
 
 #include "wall_clock.h"
 
+#include "aprs.h"
+
 static uint64_t m_unix_time_ref;
 static uint64_t m_time_base_ref;
+static bool m_time_is_valid;
 
 
 void wall_clock_init(void)
 {
 	m_unix_time_ref = 0;
 	m_time_base_ref = time_base_get();
+	m_time_is_valid = false;
 }
 
 
@@ -53,6 +57,10 @@ void wall_clock_get_utc(struct tm *time)
 	*time = *gmtime(&unix_time);
 }
 
+bool wall_clock_is_valid(void)
+{
+	return m_time_is_valid;
+}
 
 void wall_clock_set_from_gnss(const nmea_datetime_t *datetime)
 {
@@ -71,5 +79,11 @@ void wall_clock_set_from_gnss(const nmea_datetime_t *datetime)
 	if(unix_time >= 0) {
 		m_unix_time_ref = unix_time;
 		m_time_base_ref = time_base_get();
+	}
+
+	if (unix_time > 315532800) {
+		m_time_is_valid = true;
+
+		aprs_rx_history_fix_timestamp(unix_time);
 	}
 }

--- a/src/wall_clock.c
+++ b/src/wall_clock.c
@@ -32,6 +32,14 @@ static uint64_t m_unix_time_ref;
 static uint64_t m_time_base_ref;
 static bool m_time_is_valid;
 
+/**
+ * The m_unix_min_epoch defines a unix epoch, that is used to identify
+ * if the current unix_epoch is valid as a timestamp for rx packets.
+ *
+ * It can be literally anything with a large enough offset to zero.
+ * 315532800 corresponds to 1980-01-01T00:00:00Z.
+*/
+static uint64_t m_unix_min_epoch = 315532800;
 
 void wall_clock_init(void)
 {
@@ -81,7 +89,11 @@ void wall_clock_set_from_gnss(const nmea_datetime_t *datetime)
 		m_time_base_ref = time_base_get();
 	}
 
-	if (unix_time > 315532800) {
+	/**
+	 * m_time_is_valid is set to true, when the current unix_time
+	 * is greater then the min allowed unix epoche for sanity checks.
+	*/
+	if (unix_time > m_unix_min_epoch) {
 		m_time_is_valid = true;
 
 		aprs_rx_history_fix_timestamp(unix_time);

--- a/src/wall_clock.h
+++ b/src/wall_clock.h
@@ -67,6 +67,8 @@ uint64_t wall_clock_get_unix(void);
  */
 void wall_clock_get_utc(struct tm *time);
 
+bool wall_clock_is_valid(void);
+
 /**@brief Set the current time from an NMEA datetime structure.
  * @details
  * The internal time will be set immediately and continue running from there.


### PR DESCRIPTION
Added rx_time_valid information to rx'ed aprs packets. Updating rx_timestamp once time is valid

fixes #15 